### PR TITLE
git-svn test fixes

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1655,7 +1655,12 @@ repeat:
 	if (gle == ERROR_ACCESS_DENIED &&
 	    (attrs = GetFileAttributesW(wpnew)) != INVALID_FILE_ATTRIBUTES) {
 		if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
-			errno = EISDIR;
+			DWORD attrsold = GetFileAttributesW(wpold);
+			if (attrsold == INVALID_FILE_ATTRIBUTES ||
+			    !(attrsold & FILE_ATTRIBUTE_DIRECTORY))
+				errno = EISDIR;
+			else if (!_wrmdir(wpnew))
+				goto repeat;
 			return -1;
 		}
 		if ((attrs & FILE_ATTRIBUTE_READONLY) &&

--- a/t/t9118-git-svn-funky-branch-names.sh
+++ b/t/t9118-git-svn-funky-branch-names.sh
@@ -23,8 +23,11 @@ test_expect_success 'setup svnrepo' '
 	              "$svnrepo/pr ject/branches/$scary_uri" &&
 	svn_cmd cp -m "leading dot" "$svnrepo/pr ject/trunk" \
 			"$svnrepo/pr ject/branches/.leading_dot" &&
-	svn_cmd cp -m "trailing dot" "$svnrepo/pr ject/trunk" \
-			"$svnrepo/pr ject/branches/trailing_dot." &&
+	{
+		test_have_prereq MINGW ||
+		svn_cmd cp -m "trailing dot" "$svnrepo/pr ject/trunk" \
+			"$svnrepo/pr ject/branches/trailing_dot."
+	} &&
 	svn_cmd cp -m "trailing .lock" "$svnrepo/pr ject/trunk" \
 			"$svnrepo/pr ject/branches/trailing_dotlock.lock" &&
 	svn_cmd cp -m "reflog" "$svnrepo/pr ject/trunk" \
@@ -45,7 +48,10 @@ test_expect_success 'test clone with funky branch names' '
 		git rev-parse "refs/remotes/origin/more%20fun%20plugin!" &&
 		git rev-parse "refs/remotes/origin/$scary_ref" &&
 		git rev-parse "refs/remotes/origin/%2Eleading_dot" &&
-		git rev-parse "refs/remotes/origin/trailing_dot%2E" &&
+		{
+			test_have_prereq MINGW ||
+			git rev-parse "refs/remotes/origin/trailing_dot%2E"
+		} &&
 		git rev-parse "refs/remotes/origin/trailing_dotlock%2Elock" &&
 		git rev-parse "refs/remotes/origin/$non_reflog"
 	)

--- a/t/t9124-git-svn-dcommit-auto-props.sh
+++ b/t/t9124-git-svn-dcommit-auto-props.sh
@@ -35,7 +35,10 @@ test_expect_success 'enable auto-props config' '
 
 test_expect_success 'add files matching auto-props' '
 	echo "#!$SHELL_PATH" >exec1.sh &&
-	chmod +x exec1.sh &&
+	{
+		test_have_prereq !POSIXPERM ||
+		chmod +x exec1.sh
+	} &&
 	echo "hello" >hello.txt &&
 	echo bar >bar &&
 	git add exec1.sh hello.txt bar &&
@@ -49,7 +52,10 @@ test_expect_success 'disable auto-props config' '
 
 test_expect_success 'add files matching disabled auto-props' '
 	echo "#$SHELL_PATH" >exec2.sh &&
-	chmod +x exec2.sh &&
+	{
+		test_have_prereq !POSIXPERM ||
+		chmod +x exec2.sh
+	} &&
 	echo "world" >world.txt &&
 	echo zot >zot &&
 	git add exec2.sh world.txt zot &&
@@ -65,7 +71,10 @@ test_expect_success 'check resulting svn repository' '
 	cd svnrepo &&
 
 	# Check properties from first commit.
-	test "x$(svn_cmd propget svn:executable exec1.sh)" = "x*" &&
+	{
+		test_have_prereq !POSIXPERM ||
+		test "x$(svn_cmd propget svn:executable exec1.sh)" = "x*"
+	} &&
 	test "x$(svn_cmd propget svn:mime-type exec1.sh)" = \
 	     "xapplication/x-shellscript" &&
 	test "x$(svn_cmd propget svn:mime-type hello.txt)" = "xtext/plain" &&
@@ -73,7 +82,10 @@ test_expect_success 'check resulting svn repository' '
 	test "x$(svn_cmd propget svn:mime-type bar)" = "x" &&
 
 	# Check properties from second commit.
-	test "x$(svn_cmd propget svn:executable exec2.sh)" = "x*" &&
+	{
+		test_have_prereq !POSIXPERM ||
+		test "x$(svn_cmd propget svn:executable exec2.sh)" = "x*"
+	} &&
 	test "x$(svn_cmd propget svn:mime-type exec2.sh)" = "x" &&
 	test "x$(svn_cmd propget svn:mime-type world.txt)" = "x" &&
 	test "x$(svn_cmd propget svn:eol-style world.txt)" = "x" &&

--- a/t/t9130-git-svn-authors-file.sh
+++ b/t/t9130-git-svn-authors-file.sh
@@ -91,7 +91,7 @@ test_expect_success 'fetch continues after authors-file is fixed' '
 	)
 	'
 
-test_expect_success 'fresh clone with svn.authors-file in config' '
+test_expect_success !MINGW 'fresh clone with svn.authors-file in config' '
 	(
 		rm -r "$GIT_DIR" &&
 		test x = x"$(git config svn.authorsfile)" &&


### PR DESCRIPTION
I had to alter your patch a bit. `GetFileAttributesW` worked while `GetFileAttributes` did not. Was able to figure it out with `error("")` statements. Without `GetFileAttributesW` the `_wrmdir(wpnew)` call was never reached.